### PR TITLE
Fix issue with potential non-unique ids when different versions of module are bundled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ docs/index.js
 # Lasso tests temp files
 test/static/bundle-test.js
 test/static/lasso-client.js
+test/static/nanoid.js
+test/static/process.js
 
 # Unit Test & Code Coverage Reports
 reports

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://david-dm.org/makeup-js/makeup-next-id#info=devDependencies"><img src="https://david-dm.org/makeup-js/makeup-next-id/dev-status.svg" alt="devDependency status" /></a>
 </p>
 
-Assigns the next id in sequence to an element, if an id property does not already exist.
+Assigns the next id in sequence to an element, if an id property does not already exist. The id will consist of a configurable prefix (default: 'nid-'), followed by three randomly generated chars, then a number in sequence. If you need a <em>known</em> id, ahead of time, please use a different approach!
 
 A vanilla JavaScript port of <a href="https://github.com/ianmcburnie/jquery-next-id">jquery-next-id</a>.
 
@@ -36,7 +36,7 @@ const widgets = document.querySelectorAll('.widget');
 
 // assign next id to each element
 widgets.forEach(function(el) {
-    nextId(el, 'widget');
+    nextId(el);
 });
 ```
 
@@ -51,16 +51,12 @@ Markup before:
 Markup after:
 
 ```html
-<div class="widget" id="widget-1"></div>
-<div class="widget" id="widget-2"></div>
-<div class="widget" id="widget-3"></div>
+<div class="widget" id="nid-tCa-1"></div>
+<div class="widget" id="nid-tCa-2"></div>
+<div class="widget" id="nid-tCa-3"></div>
 ```
 
 ## Custom Events        
-
-* None
-
-## Dependencies
 
 * None
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,26 +1,21 @@
 <html !doctype>
-<head>
-    <title>Demo: makeup-next-id</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <style>
+    <head>
+        <title>Demo: makeup-next-id</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    </head>
+    <body>
+        <main role="main">
+            <h1>makeup-next-id</h1>
+            <p>Click button to append a new list item with generated id. Check console for output.</p>
 
-    </style>
-</head>
-<body>
-    <main role="main">
-        <h1>makeup-next-id</h1>
+            <ul id="list"></ul>
 
-        <ul id="list">
-            <li id="sas-0">Item 1</li>
-        </ul>
-
-        <form id="testForm">
-            <label>Prefix</label><input type="text" id="prefix"/>
-            <button id="appender">Append new item</button>
-        </form>
-    </main>
-
-</body>
-<!-- <lasso-body> --><script src="./static/bundle.js"></script>
+            <form id="testForm">
+                <label>Prefix</label><input type="text" id="prefix" value="nid-"/>
+                <button id="appender">Append new item</button>
+            </form>
+        </main>
+    </body>
+    <!-- <lasso-body> --><script src="./static/bundle.js"></script>
 <script>$_mod.ready();</script><!-- </lasso-body> -->
 </html>

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -9,7 +9,7 @@ const inputEl = document.getElementById('prefix');
 testForm.addEventListener('submit', function(e) {
     e.preventDefault();
     const listItem = document.createElement('li');
-    listItem.innerText = `Item ${listEl.childNodes.length - 1}`;
-    nextId(listItem, inputEl.value);
+    listItem.innerText = `Item ${listEl.childNodes.length}`;
+    console.log(`id: ${nextId(listItem, inputEl.value)}`);
     listEl.appendChild(listItem);
 });

--- a/index.js
+++ b/index.js
@@ -1,18 +1,21 @@
 'use strict';
 
+var nanoid = require('nanoid');
+
 var sequenceMap = {};
 var defaultPrefix = 'nid';
+var randomPortion = nanoid(3);
 
 module.exports = function (el) {
   var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultPrefix;
+  // join first prefix with random portion to create key
+  var key = "".concat(prefix).concat(randomPortion); // initialise key in sequence map if necessary
 
-  // prevent empty string
-  var _prefix = prefix === '' ? defaultPrefix : prefix; // initialise prefix in sequence map if necessary
-
-
-  sequenceMap[_prefix] = sequenceMap[_prefix] || 0;
+  sequenceMap[key] = sequenceMap[key] || 0;
 
   if (!el.id) {
-    el.setAttribute('id', "".concat(_prefix, "-").concat(sequenceMap[_prefix]++));
+    el.setAttribute('id', "".concat(key, "-").concat(sequenceMap[key]++));
   }
+
+  return el.id;
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,8 @@ module.exports = function (config) {
     // list of files / patterns to load in the browser
     files: [
       'test/static/lasso-client.js',
+      'test/static/nanoid.js',
+      'test/static/process.js',
       'test/static/bundle-module.js',
       'test/static/bundle-test.js',
       'test/ready.js'

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "accessibility",
     "a11y"
   ],
+  "dependencies" : {
+    "nanoid": "^2"  
+  },
   "devDependencies": {
     "@babel/cli": "^7",
     "@babel/core": "^7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,20 @@
 'use strict';
 
+const nanoid = require('nanoid');
 const sequenceMap = {};
 const defaultPrefix = 'nid';
+const randomPortion = nanoid(3);
 
 module.exports = function(el, prefix = defaultPrefix) {
-    // prevent empty string
-    const _prefix = (prefix === '') ? defaultPrefix : prefix;
+    // join first prefix with random portion to create key
+    const key = `${prefix}${randomPortion}`;
 
-    // initialise prefix in sequence map if necessary
-    sequenceMap[_prefix] = sequenceMap[_prefix] || 0;
+    // initialise key in sequence map if necessary
+    sequenceMap[key] = sequenceMap[key] || 0;
 
     if (!el.id) {
-        el.setAttribute('id', `${_prefix}-${sequenceMap[_prefix]++}`);
+        el.setAttribute('id', `${key}-${sequenceMap[key]++}`);
     }
+
+    return el.id;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,76 +1,108 @@
 var nextId = require('../index.js');
+var containerEl = document.createElement('div');
+var testEls;
 
 function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
-describe("makeup-next-id", function() {
-    var testEls;
+document.body.appendChild(containerEl);
 
-    describe('when nextId is called on elements with no id, passing no prefix', function() {
+describe('given three elements without an existing id', function() {
+    describe('when nextId is called on each element in sequence', function() {
+        var nids = [];
+
         beforeAll(function() {
-            document.body.innerHTML = '<div></div><div></div><div></div>';
-            testEls = nodeListToArray(document.querySelectorAll('div'));
+            containerEl.innerHTML = '<div></div><div></div><div></div>';
+            testEls = nodeListToArray(containerEl.querySelectorAll('div'));
+
+            nids.push(nextId(testEls[0]));
+            nids.push(nextId(testEls[1]));
+            nids.push(nextId(testEls[2]));
+        });
+
+        it('then first el should have id={id}'.replace('{id}', nids[0]), function() {
+            expect(testEls[0].id).toEqual(nids[0]);
+        });
+
+        it('then second el should have id={id}'.replace('{id}', nids[1]), function() {
+            expect(testEls[1].id).toEqual(nids[1]);
+        });
+
+        it('then third el id should have id={id}'.replace('{id}', nids[2]), function() {
+            expect(testEls[2].id).toEqual(nids[2]);
+        });
+    });
+
+    describe('when nextId is called on each element in sequence using custom prefix', function() {
+        var nids = [];
+
+        beforeAll(function() {
+            containerEl.innerHTML = '<div></div><div></div><div></div>';
+            testEls = nodeListToArray(containerEl.querySelectorAll('div'));
+
+            nids.push(nextId(testEls[0], 'foo-'));
+            nids.push(nextId(testEls[1], 'foo-'));
+            nids.push(nextId(testEls[2], 'foo-'));
+        });
+
+        it('then first el should have id={id}'.replace('{id}', nids[0]), function() {
+            expect(testEls[0].id).toEqual(nids[0]);
+        });
+
+        it('then second el should have id={id}'.replace('{id}', nids[1]), function() {
+            expect(testEls[1].id).toEqual(nids[1]);
+        });
+
+        it('then third el id should have id={id}'.replace('{id}', nids[2]), function() {
+            expect(testEls[2].id).toEqual(nids[2]);
+        });
+    });
+});
+
+describe('given three elements with an existing id', function() {
+    describe('when nextId is called on each element in sequence', function() {
+        beforeAll(function() {
+            containerEl.innerHTML = '<div id="foo-0"></div><div id="foo-1"></div><div id="foo-2"></div>';
+            testEls = nodeListToArray(containerEl.querySelectorAll('div'));
+
             nextId(testEls[0]);
             nextId(testEls[1]);
             nextId(testEls[2]);
         });
 
-        it('should set nid-0 on first element', function() {
-            expect(testEls[0].id).toEqual('nid-0');
-        });
-
-        it('should set nid-1 on second element', function() {
-            expect(testEls[1].id).toEqual('nid-1');
-        });
-
-        it('should set nid-2 on third element', function() {
-            expect(testEls[2].id).toEqual('nid-2');
-        });
-    });
-
-    describe('when nextId is called on elements with no id, passing a prefix', function() {
-        beforeAll(function() {
-            document.body.innerHTML = '<div></div><div></div><div></div>';
-            testEls = nodeListToArray(document.querySelectorAll('div'));
-
-            nextId(testEls[0], 'widget');
-            nextId(testEls[1], 'widget');
-            nextId(testEls[2], 'widget');
-        });
-
-        it('should set widget-0 on first element', function() {
-            expect(testEls[0].id).toEqual('widget-0');
-        });
-
-        it('should set widget-1 on second element', function() {
-            expect(testEls[1].id).toEqual('widget-1');
-        });
-
-        it('should set widget-2 on third element', function() {
-            expect(testEls[2].id).toEqual('widget-2');
-        });
-    });
-
-    describe('when nextId is called on elements with existing id', function() {
-        beforeAll(function() {
-            document.body.innerHTML = '<div id="foo-0"></div><div id="foo-1"></div><div id="foo-2"></div>';
-            testEls = nodeListToArray(document.querySelectorAll('div'));
-
-            nextId(testEls[0]);
-            nextId(testEls[1]);
-            nextId(testEls[2]);
-        });
-
-        it('should maintain foo-0 on first element', function() {
+        it('should maintain id=foo-0 on first element', function() {
             expect(testEls[0].id).toEqual('foo-0');
         });
 
-        it('should maintain foo-1 on second element', function() {
+        it('should maintain id=foo-1 on second element', function() {
             expect(testEls[1].id).toEqual('foo-1');
         });
 
-        it('should maintain foo-2 on third element', function() {
+        it('should maintain id=foo-2 on third element', function() {
+            expect(testEls[2].id).toEqual('foo-2');
+        });
+    });
+
+    describe('when nextId is called on each element in sequence using custom prefix', function() {
+        beforeAll(function() {
+            containerEl.innerHTML = '<div id="foo-0"></div><div id="foo-1"></div><div id="foo-2"></div>';
+            testEls = nodeListToArray(containerEl.querySelectorAll('div'));
+
+            nextId(testEls[0]);
+            nextId(testEls[1]);
+            nextId(testEls[2]);
+        });
+
+        it('should maintain id=foo-0 on first element', function() {
+            expect(testEls[0].id).toEqual('foo-0');
+        });
+
+        it('should maintain id=foo-1 on second element', function() {
+            expect(testEls[1].id).toEqual('foo-1');
+        });
+
+        it('should maintain id=foo-2 on third element', function() {
             expect(testEls[2].id).toEqual('foo-2');
         });
     });

--- a/test/lasso-config.json
+++ b/test/lasso-config.json
@@ -9,6 +9,18 @@
       ]
     },
     {
+      "name": "nanoid",
+      "dependencies": [
+        "require: nanoid"
+      ]
+    },
+    {
+      "name": "process",
+      "dependencies": [
+        "require: process"
+      ]
+    },
+    {
       "name": "bundle-module",
       "dependencies": [
         "require: ../index.js"

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -1,20 +1,24 @@
+$_mod.installed("makeup-next-id$0.0.3", "nanoid", "2.0.3");
 $_mod.def("/makeup-next-id$0.0.3/index", function(require, exports, module, __filename, __dirname) { 'use strict';
+
+var nanoid = require('/nanoid$2.0.3/index.browser'/*'nanoid'*/);
 
 var sequenceMap = {};
 var defaultPrefix = 'nid';
+var randomPortion = nanoid(3);
 
 module.exports = function (el) {
   var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : defaultPrefix;
+  // join first prefix with random portion to create key
+  var key = "".concat(prefix).concat(randomPortion); // initialise key in sequence map if necessary
 
-  // prevent empty string
-  var _prefix = prefix === '' ? defaultPrefix : prefix; // initialise prefix in sequence map if necessary
-
-
-  sequenceMap[_prefix] = sequenceMap[_prefix] || 0;
+  sequenceMap[key] = sequenceMap[key] || 0;
 
   if (!el.id) {
-    el.setAttribute('id', "".concat(_prefix, "-").concat(sequenceMap[_prefix]++));
+    el.setAttribute('id', "".concat(key, "-").concat(sequenceMap[key]++));
   }
+
+  return el.id;
 };
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4239,6 +4239,11 @@ nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
+nanoid@^2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.0.3.tgz#dde999e173bc9d7bd2ee2746b89909ade98e075e"
+  integrity sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
I ran into a situation where I had two versions of `makeup-next-id` bundled on the page with lasso. That caused the situation where generated ids were not unique, as both modules were generating ids with same sequence of `nid-0`, `nid-1`, `nid-2`, etc. resulting in clashes.

To solve this I have added a random 3 char segment between the prefix and sequence number. Now If multiple versions of makeup-next-id are bundled on same page, each version will be using it's own unique middle segment.

Before:

`nextId(el)` returns `nid-0`, `nid-1`, `nid-2`, etc

After:

`nextId(el)` returns  `nid-xxx-0`, `nid-xxx-1`, `nid-xxx-2`, etc
